### PR TITLE
link to introduction in a HTTPS/SSL-supported URL

### DIFF
--- a/README.org
+++ b/README.org
@@ -12,5 +12,5 @@ git clone https://github.com/EFLS/zd-tutorial
 Comments and additions are more than welcome, via issues or pull requests.
 
 More information in
- - an [[https://eliasstorms.net/zetteldeft][introduction to Zetteldeft]]
+ - an [[https://www.eliasstorms.net/zetteldeft][introduction to Zetteldeft]]
  - the [[https://github.com/EFLS/zetteldeft][Zetteldeft repository]]


### PR DESCRIPTION
Without the `www`, Firefox displays a security alert.